### PR TITLE
has_many association via foreign_key problem

### DIFF
--- a/activerecord/test/models/has_many_association.rb
+++ b/activerecord/test/models/has_many_association.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "bundler/inline"
+
+gemfile(true) do
+  source "https://rubygems.org"
+
+  # gem "rails"
+  # If you want to test against edge Rails replace the previous line with this:
+  gem "rails", github: "rails/rails", branch: "main"
+
+  gem "sqlite3", "~> 1.4"
+end
+
+require "active_record"
+require "minitest/autorun"
+require "logger"
+
+# This connection will do for database-independent bug reports.
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Base.logger = Logger.new(STDOUT)
+
+ActiveRecord::Schema.define do
+  create_table :posts, force: true do |t|
+    t.integer :commentable_id
+  end
+
+  create_table :comments, force: true do |t|
+    t.integer :commentable_id
+  end
+end
+
+class Post < ActiveRecord::Base
+  has_many :comments, foreign_key: :commentable_id, primary_key: :commentable_id
+end
+
+class Comment < ActiveRecord::Base
+  has_one :post, foreign_key: :commentable_id, primary_key: :commentable_id,
+          inverse_of: :comments
+end
+
+class BugTest < Minitest::Test
+  def test_association_stuff
+    commentable_id = 1
+    post = Post.create!(commentable_id: commentable_id)
+    post.comments.create!(commentable_id: commentable_id)
+
+    post = Comment.last.post
+    assert post.comments.exists?
+  end
+end


### PR DESCRIPTION
There seem to be a problem with how the `has_many` association is resolved when set up in this way. I'm not sure if this is a valid way to set this up, but nonetheless, something we've come across.

The repro case does pass in 7.1. Using the edge rails, we get the following error.

```
  1) Error:
BugTest#test_association_stuff:
NoMethodError: undefined method `none?' for an instance of Comment
    /Users/jasonkim/.local/share/mise/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/bundler/gems/rails-b9d6759401c3/activemodel/lib/active_model/attribute_methods.rb:507:in `method_missing'
    /Users/jasonkim/.local/share/mise/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/bundler/gems/rails-b9d6759401c3/activerecord/lib/active_record/attribute_methods.rb:491:in `method_missing'
    /Users/jasonkim/.local/share/mise/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/bundler/gems/rails-b9d6759401c3/activerecord/lib/active_record/relation/finder_methods.rb:371:in `exists?'
    test/models/has_many_association.rb:49:in `test_association_stuff'
```

In particular, `Comment.last.post.comments` seems to be resolving to a singular `Comment` object instead of a collection of `Comment` objects.
